### PR TITLE
Add logic to retrieve and set username in WV

### DIFF
--- a/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
+++ b/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
@@ -7,6 +7,8 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import mimeTypes from './mimeTypes'
 import { registerListener, unregisterAllListeners } from 'c/pubsub';
 import saveDocument from '@salesforce/apex/PDFTron_ContentVersionController.saveDocument';
+import Id from '@salesforce/user/Id';
+import { getRecord } from 'lightning/uiRecordApi';
 
 function _base64ToArrayBuffer(base64) {
   var binary_string =  window.atob(base64);
@@ -29,6 +31,9 @@ export default class PdftronWvInstance extends LightningElement {
 
   @wire(CurrentPageReference)
   pageRef;
+
+  @wire(getRecord, { recordId: Id, fields: ['User.FirstName', 'User.LastName']})
+  userRecord;
 
   connectedCallback() {
     registerListener('blobSelected', this.handleBlobSelected, this);
@@ -108,6 +113,12 @@ export default class PdftronWvInstance extends LightningElement {
           }).catch(error => {
             console.error(JSON.stringify(error));
           });
+          break;
+        case 'SET_USER':
+          const firstName = this.userRecord.data.fields.FirstName.value;
+          const lastName = this.userRecord.data.fields.LastName.value;
+          const username = `${firstName} ${lastName}`;
+          me.iframeWindow.postMessage({ type: 'SET_USER', username }, '*');
           break;
         default:
           break;

--- a/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
+++ b/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
@@ -76,10 +76,14 @@ export default class PdftronWvInstance extends LightningElement {
   }
 
   initUI() {
+    const firstName = this.record.data.fields.FirstName.value;
+    const lastName = this.record.data.fields.LastName.value;
+    const username = `${firstName} ${lastName}`;
     var myObj = {
       libUrl: libUrl,
       fullAPI: this.fullAPI || false,
       namespacePrefix: '',
+      username,
     };
     var url = myfilesUrl + '/webviewer-demo-annotated.pdf';
 
@@ -113,12 +117,6 @@ export default class PdftronWvInstance extends LightningElement {
           }).catch(error => {
             console.error(JSON.stringify(error));
           });
-          break;
-        case 'SET_USER':
-          const firstName = this.userRecord.data.fields.FirstName.value;
-          const lastName = this.userRecord.data.fields.LastName.value;
-          const username = `${firstName} ${lastName}`;
-          me.iframeWindow.postMessage({ type: 'SET_USER', username }, '*');
           break;
         default:
           break;

--- a/force-app/main/default/staticresources/myfiles/config_apex.js
+++ b/force-app/main/default/staticresources/myfiles/config_apex.js
@@ -62,6 +62,10 @@ async function saveDocument() {
   parent.postMessage({ type: 'SAVE_DOCUMENT', payload }, '*');
 }
 
+async function setUser(username) {
+  readerControl.docViewer.getAnnotationManager().setCurrentUser(username);
+};
+
 window.addEventListener('viewerLoaded', async function () {
   /**
    * On keydown of either the button combination Ctrl+S or Cmd+S, invoke the
@@ -85,6 +89,11 @@ window.addEventListener('viewerLoaded', async function () {
     }
     header.get('viewControlsButton').insertBefore(myCustomButton);
   });
+
+  // When the viewer has loaded, this makes the necessary call to get the
+  // pdftronWvInstance code to pass User Record information to this config file
+  // to invoke annotManager.setCurrentUser
+  parent.postMessage({ type: 'SET_USER' }, '*');
 });
 
 window.addEventListener("message", receiveMessage, false);
@@ -107,6 +116,9 @@ function receiveMessage(event) {
         break;
       case 'CLOSE_DOCUMENT':
         event.target.readerControl.closeDocument()
+        break;
+      case 'SET_USER':
+        setUser(event.data.username);
         break;
       default:
         break;

--- a/force-app/main/default/staticresources/myfiles/config_apex.js
+++ b/force-app/main/default/staticresources/myfiles/config_apex.js
@@ -62,10 +62,6 @@ async function saveDocument() {
   parent.postMessage({ type: 'SAVE_DOCUMENT', payload }, '*');
 }
 
-async function setUser(username) {
-  readerControl.docViewer.getAnnotationManager().setCurrentUser(username);
-};
-
 window.addEventListener('viewerLoaded', async function () {
   /**
    * On keydown of either the button combination Ctrl+S or Cmd+S, invoke the
@@ -93,7 +89,7 @@ window.addEventListener('viewerLoaded', async function () {
   // When the viewer has loaded, this makes the necessary call to get the
   // pdftronWvInstance code to pass User Record information to this config file
   // to invoke annotManager.setCurrentUser
-  parent.postMessage({ type: 'SET_USER' }, '*');
+  readerControl.docViewer.getAnnotationManager().setCurrentUser(custom.username);
 });
 
 window.addEventListener("message", receiveMessage, false);
@@ -116,9 +112,6 @@ function receiveMessage(event) {
         break;
       case 'CLOSE_DOCUMENT':
         event.target.readerControl.closeDocument()
-        break;
-      case 'SET_USER':
-        setUser(event.data.username);
         break;
       default:
         break;


### PR DESCRIPTION
The logic starts in the config file when `viewerLoaded` is fired because
trying to invoke `setUser` inside of the `config` too soon means the
`annotManager` APIs are not ready. As such, we need to wait for
`viewerLoaded` to be fired before calling `annotManager.setCurrentUser`,
hence the circular nature of the implemented code