### PR TITLE
Bugfix/variable naming and error handling

### DIFF
--- a/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
+++ b/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
@@ -76,8 +76,8 @@ export default class PdftronWvInstance extends LightningElement {
   }
 
   initUI() {
-    const firstName = this.record.data.fields.FirstName.value;
-    const lastName = this.record.data.fields.LastName.value;
+    const firstName = this.userRecord.data.fields.FirstName.value;
+    const lastName = this.userRecord.data.fields.LastName.value;
     const username = `${firstName} ${lastName}`;
     var myObj = {
       libUrl: libUrl,

--- a/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
+++ b/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
@@ -32,8 +32,18 @@ export default class PdftronWvInstance extends LightningElement {
   @wire(CurrentPageReference)
   pageRef;
 
-  @wire(getRecord, { recordId: Id, fields: ['User.FirstName', 'User.LastName']})
   userRecord;
+
+  @wire(getRecord, { recordId: Id, fields: ['User.FirstName', 'User.LastName']})
+  getUserRecord({ error, data }) {
+    if (data) {
+      this.userRecord = data;
+    } else if (error) {
+      console.error(error);
+      this.showNotification('Error', error.body.message, 'error');
+    }
+  }
+
 
   connectedCallback() {
     registerListener('blobSelected', this.handleBlobSelected, this);
@@ -76,8 +86,8 @@ export default class PdftronWvInstance extends LightningElement {
   }
 
   initUI() {
-    const firstName = this.userRecord.data.fields.FirstName.value;
-    const lastName = this.userRecord.data.fields.LastName.value;
+    const firstName = this.userRecord.fields.FirstName.value;
+    const lastName = this.userRecord.fields.LastName.value;
     const username = `${firstName} ${lastName}`;
     var myObj = {
       libUrl: libUrl,


### PR DESCRIPTION
This PR fixes the bug where `this.record` should actually be `this.userRecord`, and adds error handling to the retrieval of the user record information with `getRecord`