### PR TITLE
Abort UI initialization if current user data is undefined

### DIFF
--- a/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
+++ b/force-app/main/default/lwc/pdftronWvInstance/pdftronWvInstance.js
@@ -73,10 +73,13 @@ export default class PdftronWvInstance extends LightningElement {
 
   renderedCallback() {
     var self = this;
-    if (this.uiInitialized) {
+    if (this.uiInitialized || !this.userRecord) {
         return;
     }
-    this.uiInitialized = true;
+
+    if(this.userRecord) {
+      this.uiInitialized = true;
+    }
 
     Promise.all([
         loadScript(self, libUrl + '/webviewer.min.js')


### PR DESCRIPTION
* Added check to ensure `userRecord` has been retrieved by `@wire` call before initializing WebViewer UI